### PR TITLE
Update DocSet directory on Downloads page

### DIFF
--- a/downloads/downloads-index.html
+++ b/downloads/downloads-index.html
@@ -126,6 +126,6 @@ $ pod install
 <p>Un-tar it and place it in the Shared Documentation folder:</p>
 
 {% highlight bash %}
-tar -xf ~/Downloads/AudioKit.tgz -C ~/Library/Developer/Shared/Documentation/DocSets/
+tar -xf ~/Downloads/AudioKit.tgz -C /Applications/Xcode.app/Contents/Developer/Documentation/DocSets/
 {% endhighlight %}
 </div>


### PR DESCRIPTION
This seems to be the DocSet directory for Xcode 8.3—Unsure when it changed though.